### PR TITLE
Fixed typographical error, changed abilty to ability in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Use of http://api.buycraft.net is only for this plugin and integrating Buycraft 
 		- Added Purchase Signs which can be right clicked to give the user a url to click instead of using the /buy command
 		- Added proper Bungeecord support
 		- Updater now only updates to new version (Allows beta testers to moved to official release once released)
-		- Added abilty to disable and change /ec command
+		- Added ability to disable and change /ec command
 		- Added logging for errors during web requests
 		- Item GUI now supports data option
 		- Plugin now supports {UUID} as well as {name} for commands


### PR DESCRIPTION
@BuycraftPlugin, I've corrected a typographical error in the documentation of the [Buycraft-Plugin](https://github.com/BuycraftPlugin/Buycraft-Plugin) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.